### PR TITLE
Draw tile only if already loaded

### DIFF
--- a/POSM/TileLoader/TileLoader.py
+++ b/POSM/TileLoader/TileLoader.py
@@ -158,8 +158,8 @@ class TileLoader:
                 # try:
                 if pathlib.Path(path_image).is_file():
                     pic = QPixmap(str(path_image))
-                pic = pic.scaled(config.image_size, config.image_size)
-                qpainter.drawTiledPixmap(
-                    -offset_x + a * config.image_size + viewer.frameGeometry().width() * 0.5 - config.image_size * 0.5,
-                    offset_y + b * config.image_size + viewer.frameGeometry().height() * 0.5 - config.image_size * 0.5,
-                    config.image_size, config.image_size, pic)
+                    pic = pic.scaled(config.image_size, config.image_size)
+                    qpainter.drawTiledPixmap(
+                        -offset_x + a * config.image_size + viewer.frameGeometry().width() * 0.5 - config.image_size * 0.5,
+                        offset_y + b * config.image_size + viewer.frameGeometry().height() * 0.5 - config.image_size * 0.5,
+                        config.image_size, config.image_size, pic)


### PR DESCRIPTION
`get_tile` schedules the download of a tile, and drawing it does currently not depend on a finished download. If you resize fastly, you can trigger some kind of race condition here.